### PR TITLE
improv: delay the logging timeout when calling starting it multiple times

### DIFF
--- a/src/reverse/ReverseInteractor.js
+++ b/src/reverse/ReverseInteractor.js
@@ -119,7 +119,8 @@ module.exports = class ReverseInteractor {
     if (method === 'startLogging') {
       global._logs = true
       // Stop streaming logs automatically after timeout
-      setTimeout(function () {
+      clearTimeout(this._loggingTimeoutId)
+      this._loggingTimeoutId = setTimeout(function () {
         global._logs = false
       }, process.env.NODE_ENV === 'test' ? 10 : 120000)
       return callback(null, 'Log streaming enabled')


### PR DESCRIPTION
The 2 minutes timeout is a way to prevent performance overhead if the frontend doesn't stop the logging (ex: the user closes the tab).  To have logs continuously displayed in the frontend, we should be able to start again the logs when it timeouts.  But right now, the frontend can't predict when it'll timeout, because the timeout may happens before the 2 minutes if logs were already started.

Postponing the logging timeout will allow the front to safely restart logging every 2 minutes when needed.