### PR TITLE
improv: send secret key via root ping / websocket headers

### DIFF
--- a/src/InteractorDaemon.js
+++ b/src/InteractorDaemon.js
@@ -218,15 +218,14 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
    */
   _pingRoot (cb) {
     log('Ping root called %s', this.opts.ROOT_URL)
-    let data = this.getSystemMetadata()
-    data = Utility.Cipher.cipherMessage(JSON.stringify(data), this.opts.SECRET_KEY)
-    if (!data) return cb(new Error('Failed to retrieve/cipher system metadata'))
+    const data = this.getSystemMetadata()
 
     this.httpClient.open({
       url: this.opts.ROOT_URL + '/api/node/verifyPM2',
       method: 'POST',
       data: {
         public_id: this.opts.PUBLIC_KEY,
+        private_id: this.opts.SECRET_KEY,
         data: data
       }
     }, cb)

--- a/src/transporters/WebsocketTransport.js
+++ b/src/transporters/WebsocketTransport.js
@@ -3,7 +3,6 @@
 const WebSocket = require('ws')
 const log = require('debug')('interactor:websocket')
 const cst = require('../../constants.js')
-const Utility = require('../Utility.js')
 const Transporter = require('./Transporter')
 
 /**
@@ -45,15 +44,11 @@ module.exports = class WebsocketTransport extends Transporter {
     this.endpoint = url
     log('Connecting websocket transporter to %s...', url)
 
-    // cipher metadata to prove that we have the secret key
-    var data = this._daemon.getSystemMetadata()
-    data = Utility.Cipher.cipherMessage(JSON.stringify(data), this.opts.SECRET_KEY)
-
     this._ws = new WebSocket(url, {
       perMessageDeflate: false,
       headers: {
         'X-KM-PUBLIC': this.opts.PUBLIC_KEY,
-        'X-KM-DATA': data,
+        'X-KM-SECRET': this.opts.SECRET_KEY,
         'X-KM-SERVER': this.opts.MACHINE_NAME,
         'X-PM2-VERSION': this.opts.PM2_VERSION || '0.0.0',
         'X-PROTOCOL-VERSION': cst.PROTOCOL_VERSION

--- a/test/units/InteractorDaemon.mocha.js
+++ b/test/units/InteractorDaemon.mocha.js
@@ -15,7 +15,6 @@ const cst = require('../../constants')
 const clone = require('clone')
 const ModuleMocker = require('../mock/module')
 const os = require('os')
-const Utility = require('../../src/Utility')
 
 const getDaemon = () => {
   let Daemon = clone(InteractorDaemon)
@@ -269,16 +268,6 @@ describe('InteractorDaemon', () => {
     })
   })
   describe('_pingRoot', _ => {
-    it('should fail to decipher', (done) => {
-      useDaemon((daemon, cb) => {
-        daemon.getSystemMetadata = _ => {}
-        daemon._pingRoot(err => {
-          assert(err instanceof Error)
-          cb()
-          done()
-        })
-      })
-    })
     it('should launch http request', (done) => {
       useDaemon((daemon, cb) => {
         daemon.getSystemMetadata = _ => {
@@ -294,8 +283,8 @@ describe('InteractorDaemon', () => {
             assert(data.url === 'root/api/node/verifyPM2')
             assert(data.method === 'POST')
             assert(data.data.public_id === process.env.PM2_PUBLIC_KEY)
-            let cipheredData = Utility.Cipher.cipherMessage(JSON.stringify({}), process.env.PM2_SECRET_KEY)
-            assert(data.data.data === cipheredData)
+            assert(data.data.private_id === process.env.PM2_SECRET_KEY)
+            assert(JSON.stringify(data.data.data) === JSON.stringify({}))
             cb()
             done()
           }

--- a/test/units/transporters/WebsocketTransport.mocha.js
+++ b/test/units/transporters/WebsocketTransport.mocha.js
@@ -11,7 +11,6 @@ process.env.KEYMETRICS_NODE = 'http://cl1.km.io:3400'
 
 const assert = require('assert')
 const WebsocketTransport = require('../../../src/transporters/WebsocketTransport')
-const Utility = require('../../../src/Utility')
 const WebSocket = require('ws')
 
 const opts = {
@@ -52,8 +51,7 @@ describe('WebsocketTransport', () => {
 
       wss.on('connection', (ws, req) => {
         let content = req.headers
-        content['x-km-data'] = Utility.Cipher.decipherMessage(content['x-km-data'], opts.SECRET_KEY)
-        assert(typeof content['x-km-data'] === 'object')
+        assert(content['x-km-secret'] === opts.SECRET_KEY)
         assert(content['x-km-public'] === opts.PUBLIC_KEY)
         assert(content['x-pm2-version'] === opts.PM2_VERSION)
         assert(content['x-km-server'] === opts.MACHINE_NAME)
@@ -210,8 +208,7 @@ describe('WebsocketTransport', () => {
 
       wss.on('connection', (ws, req) => {
         let content = req.headers
-        content['x-km-data'] = Utility.Cipher.decipherMessage(content['x-km-data'], opts.SECRET_KEY)
-        assert(typeof content['x-km-data'] === 'object')
+        assert(content['x-km-secret'] === opts.SECRET_KEY)
         assert(content['x-km-public'] === opts.PUBLIC_KEY)
         assert(content['x-pm2-version'] === opts.PM2_VERSION)
         assert(content['x-km-server'] === opts.MACHINE_NAME)


### PR DESCRIPTION
data is send via https/wss so we don't need to cipher data, only send secret key