### PR TITLE
disable watchdog on exit - make call to cb 'synchronous' #88

### DIFF
--- a/src/InteractorClient.js
+++ b/src/InteractorClient.js
@@ -252,9 +252,6 @@ module.exports = class InteractorDaemonizer {
         return cb(msg)
       }
 
-      if (msg.km_data && msg.km_data.active === true && !process.env.PM2_SILENT) {
-        console.log('%s %s', chalk.cyan('[PM2.IO]'), msg.km_data.new ? 'Agent created' : 'Agent updated')
-      }
       return cb(null, msg, child)
     })
   }
@@ -448,7 +445,7 @@ module.exports = class InteractorDaemonizer {
       if (err || !conf) return cb(err || new Error('Cant retrieve configuration'))
 
       if (!process.env.PM2_SILENT) {
-        console.log(chalk.cyan('[PM2.IO]') + ' Using: Public key: %s | Private key: %s | Machine name: %s', conf.public_key, conf.secret_key, conf.machine_name)
+        console.log(chalk.cyan('[PM2 I/O]') + ' Using: Public key: %s | Private key: %s | Machine name: %s', conf.public_key, conf.secret_key, conf.machine_name)
       }
       return this.launchOrAttach(cst, conf, cb)
     })

--- a/src/InteractorDaemon.js
+++ b/src/InteractorDaemon.js
@@ -59,10 +59,10 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
   }
 
   /**
-   * Terminate connections and exit
+   * Terminate aconnections and exit
    * @param {cb} callback called at the end
    */
-  exit (cb) {
+  exit (err, cb) {
     log('Exiting Interactor')
     // clear workers
     if (this._workerEndpoint) clearInterval(this._workerEndpoint)
@@ -85,12 +85,12 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
       return process.exit(cst.ERROR_EXIT)
     }
 
-    cb()
+    cb && typeof(cb) === 'function' ? cb() : null
 
     setTimeout(() => {
       this._rpc.sock.close(() => {
         log('RPC server closed')
-        process.exit(cst.SUCCESS_EXIT)
+        process.exit(err ? cst.ERROR_EXIT : cst.SUCCESS_EXIT)
       })
     }, 10)
   }
@@ -108,7 +108,7 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
     rpcServer.expose({
       kill: function (cb) {
         log('Shutdown request received via RPC')
-        return self.exit(cb)
+        return self.exit(null, cb)
       },
       getInfos: function (cb) {
         if (self.opts && self.DAEMON_ACTIVE === true) {

--- a/src/InteractorDaemon.js
+++ b/src/InteractorDaemon.js
@@ -238,12 +238,11 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
    * @param {Function} cb invoked with <Error, Boolean>
    */
   _verifyEndpoint (cb) {
-    log('Verifying endpoints')
     if (typeof cb !== 'function') cb = function () {}
 
     this._pingRoot((err, data) => {
       if (err) {
-        log('Got an a error on ping root')
+        log('Got an a error on ping root', err)
         return cb(err)
       }
 
@@ -258,7 +257,6 @@ const InteractorDaemon = module.exports = class InteractorDaemon {
         return cb(null, data)
       }
 
-      log('Connect transport with endpoints')
       this.DAEMON_ACTIVE = true
       this.transport.connect(data.endpoints, cb)
     })

--- a/src/InteractorDaemon.js
+++ b/src/InteractorDaemon.js
@@ -16,6 +16,7 @@ const WatchDog = require('./WatchDog')
 const InteractorClient = require('./InteractorClient')
 const semver = require('semver')
 const path = require('path')
+const pkg = require('../package.json')
 
 // use noop if not launched via IPC
 if (!process.send) {
@@ -408,7 +409,7 @@ if (require.main === module) {
     })
   })
   d.run(_ => {
-    process.title = 'PM2 Agent (' + cst.PM2_HOME + ')'
+    process.title = `PM2 Agent v${pkg.version}: (${cst.PM2_HOME})`
 
     console.log('[PM2 Agent] Launching agent')
     new InteractorDaemon().start()

--- a/src/WatchDog.js
+++ b/src/WatchDog.js
@@ -37,6 +37,10 @@ module.exports = class WatchDog {
     })
   }
 
+  static stop() {
+    clearInterval(this.dump_interval)
+  }
+
   static resurrect () {
     debug(`Trying to launch PM2: ${path.resolve(__dirname, '../../../../bin/pm2')}`)
     child.exec(`node ${path.resolve(__dirname, '../../../../bin/pm2')} resurrect`, _ => {


### PR DESCRIPTION
https://github.com/keymetrics/pm2-io-agent/issues/88
Watchdog was keeping the agent online + it was always called when the pm2 connection was closed, causing process duplication