### PR TITLE
fix: add undeclared dependency debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "chalk": "^2.3.2",
+    "debug": "^4.1.1",
     "eventemitter2": "^5.0.1",
     "fclone": "^1.0.11",
     "moment": "^2.21.0",


### PR DESCRIPTION
This package depends on `debug` but doesn't declare it as a dependency, which causes problems if you don't have `debug` installed by some other package or when you're using Yarn PnP.

x-ref https://github.com/yarnpkg/berry/issues/795