### PR TITLE
chore: bump `proxy-agent` to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nssocket": "0.6.0",
     "pm2-axon": "~4.0.1",
     "pm2-axon-rpc": "~0.7.0",
-    "proxy-agent": "~4.0.1",
+    "proxy-agent": "~5.0.0",
     "semver": "~7.2.0",
     "ws": "~7.4.0"
   },


### PR DESCRIPTION
Resolves https://github.com/keymetrics/pm2-io-agent/issues/128.

The only change in `proxy-agent@5` is to drop Node v6 support: https://github.com/TooTallNate/node-proxy-agent/releases/tag/5.0.0