### PR TITLE
security: update semver dependency to ~7.2.0 → ~7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pm2-axon": "~4.0.1",
     "pm2-axon-rpc": "~0.7.0",
     "proxy-agent": "~5.0.0",
-    "semver": "~7.2.0",
+    "semver": "~7.5.0",
     "ws": "~7.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change allows `@pm2/agent` to depend on `semver@7.5.2` which includes a fix for this vulnerability (https://www.cve.org/CVERecord?id=CVE-2022-25883)